### PR TITLE
Update FRONTEND_INSTRUCTIONS.md

### DIFF
--- a/FRONTEND_INSTRUCTIONS.md
+++ b/FRONTEND_INSTRUCTIONS.md
@@ -256,7 +256,7 @@ Alternatively, if you want to make modifications to the theme, check out the [th
           <button class="btn btn-sm btn-outline-secondary action-btn">
             <i class="ion-plus-round"></i>
             &nbsp;
-            Follow Eric Simons <span class="counter">(10)</span>
+            Follow Eric Simons 
           </button>
         </div>
 


### PR DESCRIPTION
Removed ```<span class="counter">(10)</span>```
The API doesn't support this and it isn't shown on the demo: https://react-redux.realworld.io/#/@test11111111111111?_k=hrf8su