### PR TITLE
Remove followers count

### DIFF
--- a/FRONTEND_INSTRUCTIONS.md
+++ b/FRONTEND_INSTRUCTIONS.md
@@ -460,7 +460,7 @@ Alternatively, if you want to make modifications to the theme, check out the [th
         <button class="btn btn-sm btn-outline-secondary">
           <i class="ion-plus-round"></i>
           &nbsp;
-          Follow Eric Simons <span class="counter">(10)</span>
+          Follow Eric Simons
         </button>
         &nbsp;
         <button class="btn btn-sm btn-outline-primary">


### PR DESCRIPTION
Since the API does not return count of followers for a profile, it should be removed from the templates provided here. You can see the profile object here in the API spec:

https://github.com/gothinkster/realworld/tree/master/api#profile